### PR TITLE
change the name of the package

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "ts-gen",
+  "name": "tgen",
   "version": "0.0.1",
   "main": "dist/index.js",
   "types": "dist/types/index.d.ts",


### PR DESCRIPTION
- change name of the package

because the npm registry hindered the package to be published (similarity name)

